### PR TITLE
Support for Jekyll 2 & 3

### DIFF
--- a/lib/octopress-content-for/version.rb
+++ b/lib/octopress-content-for/version.rb
@@ -1,7 +1,7 @@
 module Octopress
   module Tags
     module ContentFor
-      VERSION = "1.0.4"
+      VERSION = "1.0.5"
     end
   end
 end

--- a/octopress-content-for.gemspec
+++ b/octopress-content-for.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "octopress-tag-helpers", "~> 1.0"
-  spec.add_runtime_dependency "jekyll", "~> 2.0"
+  spec.add_runtime_dependency "jekyll", ">= 2.0"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
It looks like you might have missed a plugin in your bunch of Jekyll 3 gemspec updates. This one is currently preventing `octopress-genesis-theme` from being installed, because some new dependencies require Jekyll 3 explicitly (for example [octopress/escape-code](https://github.com/octopress/escape-code/commit/8b449753c28b1f2bb54dd5f70b5454d3bdcb0f26#diff-a1fae13d9f9933062f761e2d3bc978f1R21) in this commit).

For example, `bundle install` on this Gemfile fails:

``` ruby
source "http://rubygems.org"

gem 'jekyll', '>= 3.0'
gem 'octopress', '>= 3.0'
gem 'octopress-ink'

group :jekyll_plugins do
  gem 'octopress-genesis-theme'
end
```

but succeeds with this patch applied:

``` diff
diff a/Gemfile b/Gemfile
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,6 @@ gem 'octopress', '>= 3.0'
 gem 'octopress-ink'

 group :jekyll_plugins do
+  gem 'octopress-content-for', git: 'https://github.com/jez/content-for.git'
   gem 'octopress-genesis-theme'
 end
```

I believe that this also solves octopress/genesis-theme#45. The issue mentions `octopress-date-format`, and I suspected this gem as well at first. However, this gem is the root of the issue. I think bundler merely took a greedy approach to showing dependency mismatch errors.
